### PR TITLE
Recognize Flatpak apps as "native"

### DIFF
--- a/xoptions.cpp
+++ b/xoptions.cpp
@@ -1534,7 +1534,7 @@ bool XOptions::checkNative(const QString &sIniFileName)
     QString sApplicationDirPath = qApp->applicationDirPath();
 
     if ((sApplicationDirPath == "/bin") || (sApplicationDirPath == "/usr/bin") || (sApplicationDirPath == "/usr/local/bin") ||
-        (sApplicationDirPath.contains("/usr/local/bin$")) || isAppImage()) {
+        (sApplicationDirPath == "/app/bin") || (sApplicationDirPath.contains("/usr/local/bin$")) || isAppImage()) {
         bResult = true;
     } else {
         bResult = false;


### PR DESCRIPTION
[Flatpak](https://flatpak.org/about/) is a popular packaging format on Linux, and every regular Flatpak app installs their binaries to `/app/bin`.