### PR TITLE
update memory

### DIFF
--- a/xoptions.cpp
+++ b/xoptions.cpp
@@ -1917,6 +1917,8 @@ void XOptions::registerCodecs()
             qFatal("Codec failed");
         }
         // TODO more codecs
+
+		delete pCodec;
     }
 #endif
 }


### PR DESCRIPTION
Ensure proper memory management by deleting dynamically allocated codec_cp437 object to prevent memory leaks.