### PR TITLE
Update application data path for Linux Flatpak

### DIFF
--- a/xoptions.cpp
+++ b/xoptions.cpp
@@ -1816,6 +1816,8 @@ QString XOptions::getApplicationDataPath()
             QString sPrefix = sApplicationDirPath.section("/usr/local/bin", 0, 0);
 
             sResult += sPrefix + QString("/usr/local/lib/%1").arg(qApp->applicationName());
+        } else if (sApplicationDirPath.startsWith("/app/bin")) { // Flatpak
+            sResult += QString("/app/lib/%1").arg(qApp->applicationName());
         } else {
             if (sApplicationDirPath.contains("/tmp/.mount_"))  // AppImage
             {


### PR DESCRIPTION
When building the Flatpak package of Detect It Easy using QMake, all databases are installed to `/app/lib/die` by default, but the default search path for them was `/usr/lib/die` instead.

This change makes `/app/lib/die` the default search path when we detect a Flatpak installation.

### Before:

![before](https://github.com/user-attachments/assets/02e0d6b6-89df-445f-b3b2-7094f8fe6751)

### After:

![after](https://github.com/user-attachments/assets/2ca1f37a-a295-4ae1-b1c3-b950c0d79da7)
